### PR TITLE
Vanity Generator v1 (and debug mode disabled)

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,6 +69,11 @@
             <button onclick="generateWallet()">Create A New Wallet</button>
           </div>
           <br>
+          <div id='generateVanityWallet'>
+            <input style="display:none;" type="text" id='prefix' placeholder="Address Prefix">
+            <button onclick="generateVanityWallet()">Create A Vanity Wallet</button>
+          </div>
+          <br>
             <button id='wToggle'onclick='toggleWallet()'>Access My Wallet</button>
           <br>
           <br>
@@ -214,6 +219,9 @@
     <script>
     function toggleWallet(){
       var toggle = document.getElementById("wToggle").innerHTML;
+      // Hide and Reset the Vanity address input
+      document.getElementById('prefix').value = "";
+      document.getElementById('prefix').style.display = 'none';
       if(toggle === "Access My Wallet"){
         document.getElementById("generateWallet").style.display = 'none';
         document.getElementById("importWallet").style.display = 'block';
@@ -222,6 +230,33 @@
         document.getElementById("generateWallet").style.display = 'block';
         document.getElementById("importWallet").style.display = 'none';
         document.getElementById("wToggle").innerHTML = "Access My Wallet";
+      }
+    }
+    async function generateVanityWallet() {
+      // Generate a vanity address with the given prefix
+      let strPrefix = document.getElementById('prefix');
+      if (strPrefix.value.length === 0) {
+        // No prefix, display the intro!
+        strPrefix.style.display = 'block';
+        document.getElementById('genKeyWarning').style.display = 'block';
+        document.getElementById('Privatelabel').style.display = 'block';
+        document.getElementById('Publiclabel').style.display = 'block';
+        document.getElementById('PrivateTxt').innerHTML = "---";
+        document.getElementById('PublicTxt').innerHTML = "---";
+      } else {
+        // We also don't want users to be mining addresses for years... so cap the letters to four until the generator is more optimized
+        if (strPrefix.value.length > 4) return alert("This is a long name! This would take a LONG time to find, please choose a shorter name!");
+        // Cache a lowercase equivilent for lower-entropy comparisons (a case-insensitive search is ALOT faster!) and strip accidental spaces
+        const nInsensitivePrefix = strPrefix.value.toLowerCase().replace(/ /g, "");
+        let attempts = 0;
+        // Begin the search, cap'n!!!
+        while (true) {
+          let nWallet = await generateWallet(nInsensitivePrefix);
+          // Check if the prefix matches the pubkey...
+          if (nWallet.vanity_match) return console.log("VANITY: Found an address after " + attempts + " attempts!");
+          // No match, bump the attempts
+          attempts++;
+        }
       }
     }
     function toggleDropDown(id){

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -1,5 +1,5 @@
 //Settings Defaults
-var debug = true;
+var debug = false;
 var explorer = 'explorer.dogec.io';
 var networkEnabled = true;
 //Users need not look below here.

--- a/scripts/wallet.js
+++ b/scripts/wallet.js
@@ -163,8 +163,8 @@ importWallet= function(){
 }
 
 //Wallet Generation
-generateWallet = function() {
-  if(walletAlreadyMade != 0){
+generateWallet = async function (strPrefix = false) {
+  if (walletAlreadyMade != 0 && strPrefix === false) {
     var walletConfirm = window.confirm("Do you really want to generate a new address? If you haven't saved the last private key the key will get lost forever and any funds with it.");
   }else{
     walletConfirm = true;
@@ -224,7 +224,7 @@ generateWallet = function() {
     var pubKey = to_b58(hexStringToByte(pubKeyPreBase), MAP)
     publicKeyForNetwork = pubKey;
     //Debug Console
-    if(debug){
+    if(debug && strPrefix === false){
       console.log("Private Key")
       console.log(privateKeyHex)
       console.log("Private Key Plus Leading Digits")
@@ -256,24 +256,37 @@ generateWallet = function() {
       console.log('Public Key Base 64')
       console.log(pubKey)
     }
-    //Display Text
-    document.getElementById('genKeyWarning').style.display = 'block';
-    document.getElementById('Privatelabel').style.display = 'block';
-    document.getElementById('Publiclabel').style.display = 'block';
-    document.getElementById('PrivateTxt').innerHTML = privateKeyWIF;
-    document.getElementById('PublicTxt').innerHTML = pubKey;
-    //QR Codes
-    var typeNumber = 4;
-    var errorCorrectionLevel = 'L';
-    var qr = qrcode(typeNumber, errorCorrectionLevel);
-    qr.addData('dogecash:'+privateKeyWIF);
-    qr.make();
-    document.getElementById('PrivateQR').innerHTML = qr.createImgTag();
-    var typeNumber = 4;
-    var errorCorrectionLevel = 'L';
-    var qr = qrcode(typeNumber, errorCorrectionLevel);
-    qr.addData('dogecash:'+pubKey);
-    qr.make();
-    document.getElementById('PublicQR').innerHTML = qr.createImgTag();
+    // VANITY ONLY: During a search, we don't update the DOM until a match is found, or the renderer consumes a shitload of resources.
+    let nRet = {
+      pubkey: null,
+      privkey: null,
+      vanity_match: false
+    }
+    if (strPrefix === false || (strPrefix !== false && pubKey.toLowerCase().startsWith(strPrefix))) {
+      //Display Text
+      document.getElementById('genKeyWarning').style.display = 'block';
+      document.getElementById('Privatelabel').style.display = 'block';
+      document.getElementById('Publiclabel').style.display = 'block';
+      document.getElementById('PrivateTxt').innerHTML = privateKeyWIF;
+      document.getElementById('PublicTxt').innerHTML = pubKey;
+      //QR Codes
+      var typeNumber = 4;
+      var errorCorrectionLevel = 'L';
+      var qr = qrcode(typeNumber, errorCorrectionLevel);
+      qr.addData('dogecash:'+privateKeyWIF);
+      qr.make();
+      document.getElementById('PrivateQR').innerHTML = qr.createImgTag();
+      var typeNumber = 4;
+      var errorCorrectionLevel = 'L';
+      var qr = qrcode(typeNumber, errorCorrectionLevel);
+      qr.addData('dogecash:'+pubKey);
+      qr.make();
+      document.getElementById('PublicQR').innerHTML = qr.createImgTag();
+      // VANITY ONLY: If we reached here during a vanity search, we found our match!
+      nRet.pubkey       = pubKey;
+      nRet.privkey      = privateKeyWIF;
+      nRet.vanity_match = true;
+    }
+    return nRet;
   }
 }


### PR DESCRIPTION
Vanity Generator v1 has been ported from SCC web 3.0 to the DogeCash web wallet, this is an extremely simple VanityGen replica, with the ability to create short custom prefixes up to 3 or 4 letters max, currently.

Debug mode has been disabled by default, I don't think it should be enabled on a _production_ repo, but also; the Vanity Generator would get stuck in a permanent loop in debug mode, because the mode only uses a single pre-determined address.

The generator is single-threaded and runs in the renderer process, which means the site will 'lock up' during the generation, this limitation will eventually be bypassed with multi-threaded background workers, but until then, the site will only allow a maximum of 4 custom letters, as higher would currently take a painful amount of time, until further optimized!

Have fun!